### PR TITLE
Added cutoff consideration

### DIFF
--- a/Stage3.py
+++ b/Stage3.py
@@ -98,7 +98,7 @@ def return_candidates(list_of_targets, initial_seq, genes_sg_dict, Omega, df, no
 			prob_gene_cut = 1 - prob_gene_will_not_cut
 			if for_single_gene: # is this necessary? omer 11/4
 				genes_covering.append((gene, num_of_cuts_per_gene))
-			if prob_gene_cut > Omega:
+			if prob_gene_cut >= Omega:
 				targets_dict[gene] = list_of_targets
 				genes_covering.append((gene, prob_gene_cut))
 		cut_expection = 0  ##the probability the permutationed sequence will cut all of the genes, that the probability each of them will be cut is greater then Omega
@@ -106,7 +106,7 @@ def return_candidates(list_of_targets, initial_seq, genes_sg_dict, Omega, df, no
 		for tuple in genes_covering:  #tuple : (gene name, probability to be cut)
 			cut_expection += tuple[1]  ## the prob to cut all the genes
 			genes_score_dict[tuple[0]] = tuple[1]
-		if len(genes_covering) >= 1: #changed from cut expectation to the number of genes cut. omer 11/04
+		if len(genes_covering) >= 1: #If the candidate has at least one gene with a score above Omega, add it to the result  omer 18/04
 			current_candidate = Candidate.Candidate(list_of_perms_sequs[i], cut_expection, genes_score_dict, targets_dict)
 			list_of_candididates.append(current_candidate)
 	del list_of_perms_sequs

--- a/Stage3.py
+++ b/Stage3.py
@@ -96,18 +96,17 @@ def return_candidates(list_of_targets, initial_seq, genes_sg_dict, Omega, df, no
 				prob_gene_will_not_cut = prob_gene_will_not_cut * (1- candidate_cut_prob)  #lowering the not cut prob in each sgRNA
 				num_of_cuts_per_gene += candidate_cut_prob
 			prob_gene_cut = 1 - prob_gene_will_not_cut
-			if len(list_of_targets) > 0:
-				targets_dict[gene] = list_of_targets  #targets of this gene to be cleaved by the current candidate
-			if (for_single_gene):
+			if for_single_gene: # is this necessary? omer 11/4
 				genes_covering.append((gene, num_of_cuts_per_gene))
-			else:
+			if prob_gene_cut > Omega:
+				targets_dict[gene] = list_of_targets
 				genes_covering.append((gene, prob_gene_cut))
 		cut_expection = 0  ##the probability the permutationed sequence will cut all of the genes, that the probability each of them will be cut is greater then Omega
 		genes_score_dict = {}  # a dict of genes: genes considered cut by this sequence, and cut prob
 		for tuple in genes_covering:  #tuple : (gene name, probability to be cut)
 			cut_expection += tuple[1]  ## the prob to cut all the genes
 			genes_score_dict[tuple[0]] = tuple[1]
-		if cut_expection >= 1: #is this condition necessary? should be commented out since some functions would return an empty input. Omer Caldararu 30/3
+		if len(genes_covering) >= 1: #changed from cut expectation to the number of genes cut. omer 11/04
 			current_candidate = Candidate.Candidate(list_of_perms_sequs[i], cut_expection, genes_score_dict, targets_dict)
 			list_of_candididates.append(current_candidate)
 	del list_of_perms_sequs

--- a/mafft_and_phylip.py
+++ b/mafft_and_phylip.py
@@ -54,7 +54,7 @@ def FASTA_to_PHYLIP_old(in_file, out_file):
 	return out_file
 
 # def FASTA_to_PHYLIP(in_f, out_f):
-# 	os.system('perl ' + PATH +  '/convertMsaFormat.pl '+in_f + ' ' +out_f+' fasta phylip')
+# os.system('perl ' + PATH +  '/convertMsaFormat.pl '+in_f + ' ' +out_f+' fasta phylip')
 
 def FASTA_to_PHYLIP(in_f, out_f):
 	'''


### PR DESCRIPTION
- Stage3.return_candidates will now check if the candidate-gene score (prob_gene_cut) is above the threshold before adding it to the list of genes covered by the candidate.

- return_candidates will now check that the number of cut genes is above 1 before adding the candidate to the list, rather than checking if the sum of genes scores (cut_expectation) is >=1 (this change is relevant when using distance functions where a perfect match is given a score lower than 1)

NOTE: This changes the output of the tester since the threshold is now taken into account.