### PR TITLE
Family name changes:

### DIFF
--- a/Stage0.py
+++ b/Stage0.py
@@ -20,7 +20,7 @@ from CRISPR_Net.CrisprNetLoad import load_crispr_net
 from MOFF.MoffLoad import load_moff
 from DeepHF.LoadDeepHF import load_deephf
 from crispys_chips import chips_main
-from singletons import singletons_main
+# from singletons import singletons_main
 
 # get the output_path of this script file
 PATH = os.path.dirname(os.path.realpath(__file__))

--- a/Stage1.py
+++ b/Stage1.py
@@ -186,7 +186,7 @@ def genes_tree_top_down(res: List, node: CladeNew, genes_of_interest_set: set, o
     targets_names = list()
 
     if N_genes_in_node >= len(
-            node.node_leaves) or (node.is_terminal() and singletons_from_crispys):
+            node.node_leaves) > 1 or (node.is_terminal() and singletons_from_crispys):
         for leaf in node.node_leaves:  # leaf here is a gene. taking only the relevant genes
             current_genes_targets_dict[leaf] = genes_targets_dict[leaf]
             # filling the targets to genes dict
@@ -200,6 +200,9 @@ def genes_tree_top_down(res: List, node: CladeNew, genes_of_interest_set: set, o
                     targets_names.append(target)
 
         best_permutations = []
+        # If there are no targets in the internal node, return None
+        if not current_genes_targets_dict:
+            return
         # If a desired genes file was defined, and the internal node does not satisfy the conditions, move to the next
         # internal node & don't enter Stage2.
         if not genes_of_interest_set or determine_if_relevant_node(node, genes_of_interest_set,

--- a/run_crispys_on_families.py
+++ b/run_crispys_on_families.py
@@ -78,9 +78,24 @@ def create_crispys_command(code_path: str, fam_fasta_path: str, fam_dir_path: st
     command += f"--singletons_on_target_function {singletons_on_target_function} "
     command += f"--number_of_singletons {number_of_singletons} "
 
-
     return command
 
+
+def contains_genes_of_interest(fam_fasta_path, set_of_genes_of_interest):
+    """
+    This f
+    :param set_of_genes_of_interest:
+    :param fam_fasta_path:
+    :return:
+    """
+    with open(fam_fasta_path,'r') as f:
+        lines = f.readlines()
+
+    fasta_gene_names_set = {gene.strip(">\n") for gene in lines if gene.startswith(">")}
+    intersection_set = {gene for gene in fasta_gene_names_set if gene in set_of_genes_of_interest}
+    if intersection_set:
+        return True
+    return False
 
 def run(code_path: str, main_folder_path: str, genes_of_interest_file: str = "None", ncpu: int = 1, mem: int = 8,
         queue="itaym",
@@ -90,7 +105,8 @@ def run(code_path: str, main_folder_path: str, genes_of_interest_file: str = "No
         max_target_polymorphic_sites: int = 12, pams: int = 0, singletons_from_crispys: int = 0, slim_output: int = 0,
         set_cover: int = 0, desired_genes_fraction_threshold: float = -1.0, chips: int = 0, number_of_groups: int = 20,
         n_with_best_guide: int = 5, n_sgrnas: int = 2, singletons: int = 0,
-                 singletons_on_target_function: str = "ucrispr", number_of_singletons: int = 50):
+        singletons_on_target_function: str = "ucrispr", number_of_singletons: int = 50,
+        check_for_genes_of_interest: bool = False):
     """
     A wrapper function to run CRISPys on the cluster for multiple folders.
     Args:
@@ -125,17 +141,26 @@ def run(code_path: str, main_folder_path: str, genes_of_interest_file: str = "No
         singletons: select 1 to create singletons (sgRNAs candidates that target a single gene).
         number_of_singletons: the number of singletons that will be included for each gene.
         singletons_on_target_function: The on-target scoring function used for evaluating singletons.
+        check_for_genes_of_interest: optional: checks if the fasta file contains any genes of interest before submitting
+        the job for that particular family
     Returns:
-        Runs CRISPys-CRUNCH on each folder
+        :param
     """
     families = os.listdir(main_folder_path)
     family_output_name = output_name
+    if check_for_genes_of_interest:
+        with open(genes_of_interest_file,'r') as f:
+            genes_of_interest_lines = f.readlines()
+        set_of_genes_of_interest={gene.strip() for gene in genes_of_interest_lines}
+
     for i, family in enumerate(families):
         fam_dir_path = os.path.join(main_folder_path, family)
         if os.path.isdir(fam_dir_path) and not family.startswith("."):
             if include_family_name_in_output:
                 family_output_name = f"{family}_{output_name}"
             fam_fasta_path = os.path.join(fam_dir_path, f"{family}.fa")
+            if check_for_genes_of_interest and not contains_genes_of_interest(fam_fasta_path, set_of_genes_of_interest):
+                continue
             header = createHeaderJob(fam_dir_path, job_name=family_output_name, ncpu=ncpu, mem=mem, queue=queue)
             sh_file = os.path.join(fam_dir_path, f"crispys_{family_output_name}.sh")
             command = create_crispys_command(code_path=code_path, fam_fasta_path=fam_fasta_path,
@@ -147,7 +172,8 @@ def run(code_path: str, main_folder_path: str, genes_of_interest_file: str = "No
                                              on_scoring_function=on_scoring_function, start_with_g=start_with_g,
                                              internal_node_candidates=internal_node_candidates,
                                              max_target_polymorphic_sites=max_target_polymorphic_sites, pams=pams,
-                                             singletons_from_crispys=singletons_from_crispys, slim_output=slim_output, set_cover=set_cover,
+                                             singletons_from_crispys=singletons_from_crispys, slim_output=slim_output,
+                                             set_cover=set_cover,
                                              desired_genes_fraction_threshold=desired_genes_fraction_threshold,
                                              chips=chips, number_of_groups=number_of_groups,
                                              n_with_best_guide=n_with_best_guide, n_sgrnas=n_sgrnas,
@@ -159,9 +185,9 @@ def run(code_path: str, main_folder_path: str, genes_of_interest_file: str = "No
 
 
 if __name__ == '__main__':
-    run(main_folder_path="/groups/itay_mayrose/caldararu/test_chips/",
+    run(main_folder_path="/groups/itay_mayrose/caldararu/crispys_arabidopsis/families/",
         code_path="/groups/itay_mayrose/caldararu/tmp/crispys/Stage0.py", include_family_name_in_output=True,
-        genes_of_interest_file="None",
+        genes_of_interest_file="/groups/itay_mayrose/caldararu/crispys_arabidopsis/genes_of_interest.txt", queue="itaym",
         desired_genes_fraction_threshold=-1.0, algorithm="gene_homology", slim_output=1, off_scoring_function="moff",
-        omega=0.1, output_name="test_chips_csv_0.1", internal_node_candidates=200, singletons_from_crispys=0, mem=16, ncpu=1,
-        max_target_polymorphic_sites=12, set_cover=0, chips=1, number_of_groups=20, n_with_best_guide=10)
+        omega=0.09, output_name="ath_moff_0.09", internal_node_candidates=200, singletons_from_crispys=0, mem=16,
+        ncpu=1, max_target_polymorphic_sites=12, set_cover=0, chips=0, check_for_genes_of_interest=True)


### PR DESCRIPTION
- Added an option to check for genes of interest in each family before running crispys on a family. This should reduce the number of jobs submitted to the cluster.
- Fixed a bug where CRISPys would not work properly on genes with no targets.
- Fixed a bug where CRISPys would still look for sgRNAs in single-gene internal nodes, even if "singletons from CRISPys" was set to 0.